### PR TITLE
add updates to fullstory cloud mode destination docs

### DIFF
--- a/src/connections/destinations/catalog/actions-fullstory-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-fullstory-cloud/index.md
@@ -13,9 +13,9 @@ versions:
 
 [FullStory](https://www.fullstory.com/){:target="_blank"} lets product and support teams easily understand everything about the customer experience. The Segment integration for FullStory helps accurately identify your customers within FullStory.
 
-FullStory’s cloud mode Segment integration allows you send user and event data to FullStory from your servers and Cloud Apps so that you apply it to your analysis throughout FullStory. For example, you could build a funnel to analyze drop-off of users who engaged with a certain marketing campaign.
+FullStory’s cloud mode Segment integration allows you to enrich FullStory data by sending user properties and events from your servers and Cloud Apps so that you apply it to your analysis throughout FullStory. For example, you could build a funnel to analyze drop-off of users who engaged with a certain marketing campaign.
 
-If you want to use FullStory’s tagless autocapture, use the [FullStory Device Mode (Actions) web destination](/docs/connections/destinations/catalog/actions-fullstory/). However, if you want to capture custom user properties and events from other [server-side sources](/docs/connections/sources/#server) or [cloud apps](/docs/connections/sources/#cloud-apps), such as recurring subscription purchases, use this cloud mode destination.
+FullStory’s cloud mode destination requires that you also use FullStory’s tagless autocapture, available through the [FullStory Device Mode (Actions) web destination](/docs/connections/destinations/catalog/actions-fullstory/). However, if you want to enrich the autocapture data with custom user properties and events from other [server-side sources](/docs/connections/sources/#server) or [cloud apps](/docs/connections/sources/#cloud-apps), such as recurring subscription purchases, use this cloud mode destination.
 
 ### Overview
 
@@ -26,19 +26,21 @@ The FullStory cloud mode destination sends information about your users and rela
 
 ### Benefits of FullStory Cloud Mode (Actions)
 
-- Works with FullStory’s latest data capture APIs
+- Enrich autocapture data with FullStory’s latest data capture APIs
 - Ability to send custom events from new sources
 - Use [Destination Filters](/docs/connections/destinations/destination-filters/) to selectively send certain events or user properties to FullStory
 
 ### Getting Started
 
 1. You need a FullStory API Key to use the FullStory cloud mode destination. Refer to [this article](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys){:target="_blank"} to learn how to generate a new API Key within FullStory.
-2. From the Segment web app, click **Catalog**, then click **Destinations**.
+2. From the Segment web app, click **Catalog**, then click **Destinations**.
 3. Find “FullStory Cloud Mode (Actions)” in the Destinations list and click it.
-4. Click **Configure FullStory Cloud Mode (Actions)**.
+4. Click **Configure FullStory Cloud Mode (Actions)**.
 5. Select an existing Source to connect to FullStory Cloud Mode (Actions).
 6. Provide a Destination Name and select **Fill in settings manually.** Ensure the “Actions” destinations framework is selected and click **Save.**
 7. On the **Basic Settings** page, enter your FullStory API Key from step 1 and click **Save Changes**.
-8. On the **Mappings** tab, you can view default mappings as well as add, modify, or disable mappings.
+8. On the **Mappings** tab, you can view default mappings as well as add, modify, or disable mappings. Confirm that the "User ID" FullStory property is mapped to the ID previously used to identify the user. For more information, please refer to the [API documentation](https://developer.fullstory.com/server-events){:target="_blank"}.
+
+Please note: Events sent through Segment Cloud Mode count towards your FullStory server event quota. To see your company’s current quota allotment, view the Subscription information in your Account Settings within FullStory.
 
 {% include components/actions-fields.html %}


### PR DESCRIPTION
### Proposed changes

We've received feedback that customers expect Cloud Mode to "just work" by flipping it on, yet they miss the requirement that users need to be previously-identified using FS.identify. We already made an [update](https://help.fullstory.com/hc/en-us/articles/360020828993-Segment#01G8E65G3SC5YEXR006VDX6XTR) to our KB article to call out this requirement more prominently. Here we are doing the same for our Segment Docs

### Merge timing
as soon as possible or as soon as its approved
